### PR TITLE
Updating unzipped folder path to match twilio.com docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Type the following in a terminal:
 ```
 wget https://github.com/twilio/wireless-ppp-scripts/archive/master.zip
 unzip master.zip
-cd wireless-ppp-scripts
+cd wireless-ppp-scripts-master
 sudo cp chatscripts/twilio /etc/chatscripts
 sudo cp peers/twilio /etc/ppp/peers
 ```

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ cd wireless-ppp-scripts-master
 sudo cp chatscripts/twilio /etc/chatscripts
 sudo cp peers/twilio /etc/ppp/peers
 ```
-Thats it for the scripts. You can remove master.zip and wireless-ppp-scripts by typing the following in a terminal:
+Thats it for the scripts. You can remove master.zip and wireless-ppp-scripts-master by typing the following in a terminal:
 ```
 rm -rf master.zip
-rm -rf wireless-ppp-scripts
+rm -rf wireless-ppp-scripts-master
 ```
 ## Step 4. Shut down wifi if up
 Type the following in a terminal:


### PR DESCRIPTION
I noticed that the unzipped folder path in this repo's README didn't quite match the docs at https://www.twilio.com/docs/wireless/quickstart/raspberry-pi-headless-usb-modem so I'm updating it to match.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
